### PR TITLE
Autologin for on before and after methods

### DIFF
--- a/src/Glpi/Test/CommonTestCase.php
+++ b/src/Glpi/Test/CommonTestCase.php
@@ -41,6 +41,13 @@ abstract class CommonTestCase extends CommonDBTestCase
 
    public function beforeTestMethod($method) {
       self::resetGLPILogs();
+      switch ($method){
+         case 'testShowForm':
+         case 'testPrepareInputForAdd':
+         case 'testPrepareInputForUpdate':
+            $this->login('glpi', 'glpi');
+            break;
+      }
    }
 
    protected function resetState() {
@@ -114,6 +121,14 @@ abstract class CommonTestCase extends CommonDBTestCase
    }
 
    public function afterTestMethod($method) {
+      switch ($method) {
+         case 'testShowForm':
+         case 'testPrepareInputForAdd':
+         case 'testPrepareInputForUpdate':
+            \Session::destroy();
+            break;
+      }
+
       // Check logs
       $fileSqlContent = file_get_contents(GLPI_LOG_DIR."/sql-errors.log");
       $filePhpContent = file_get_contents(GLPI_LOG_DIR."/php-errors.log");


### PR DESCRIPTION
Hello,

This changes allows to do the login and logout process for some special test methods used in flyvemdm plugin that need access like an user.